### PR TITLE
fix: Overlay problem in IE8: getBoundingClientRect does not support width & height 

### DIFF
--- a/src/query/offset.js
+++ b/src/query/offset.js
@@ -18,14 +18,12 @@ module.exports = function offset(node) {
   if (node.getBoundingClientRect !== undefined)
     box = node.getBoundingClientRect();
 
-  if ( box.width || box.height ) {
-
-    box = {
-      top:    box.top  + (win.pageYOffset || docElem.scrollTop)  - (docElem.clientTop  || 0),
-      left:   box.left + (win.pageXOffset || docElem.scrollLeft) - (docElem.clientLeft || 0),
-      width:  (box.width  == null ? node.offsetWidth  : box.width)  || 0,
-      height: (box.height == null ? node.offsetHeight : box.height) || 0
-    }
+  // IE8 getBoundingClientRect doesn't support width & height
+  box = {
+    top:    box.top  + (win.pageYOffset || docElem.scrollTop)  - (docElem.clientTop  || 0),
+    left:   box.left + (win.pageXOffset || docElem.scrollLeft) - (docElem.clientLeft || 0),
+    width:  (box.width  == null ? node.offsetWidth  : box.width)  || 0,
+    height: (box.height == null ? node.offsetHeight : box.height) || 0
   }
 
   return box


### PR DESCRIPTION
Just remove "if ( box.width || box.height )".
if getBoundingClientRect return undefined width and height then it will be set.
