### PR TITLE
Implement listen utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dom-helpers
 
-tiny modular DOM lib for ie8+ 
+tiny modular DOM lib for ie8+
 
 ## Install
 
@@ -15,10 +15,10 @@ For example `events.on` works in all browsers ie8+ but it uses the native event 
 
 ```js
 if (document.addEventListener)
-  return (node, eventName, handler, capture) => 
+  return (node, eventName, handler, capture) =>
     node.addEventListener(eventName, handler, capture || false);
 else if (document.attachEvent)
-  return (node, eventName, handler) => 
+  return (node, eventName, handler) =>
       node.attachEvent('on' + eventName, handler);
 ```
 
@@ -60,12 +60,12 @@ Each level of the module can be required as a whole or you can drill down for a 
         - `addClass(element, className)`
         - `removeClass(element, className)`
         - `hasClass(element, className)`
-    - `style(element, propName, [value])` or `style(element, objectOfPropValues)` 
+    - `style(element, propName, [value])` or `style(element, objectOfPropValues)`
         + `removeStyle(element, styleName)`
         + `getComputedStyle(element)` -> `getPropertyvalue(name)`
     - transition
         + `end(node, handler, [duration])` listens for transition end, and ensures that the handler if called even if the transition fails to fire its end event. Will attempt to read duration from the element, otherwise one can be provided
-        + `properties`: Object containing the various vendor specifc transition and transform properties for your browser 
+        + `properties`: Object containing the various vendor specifc transition and transform properties for your browser
         ```js
            {
             transform: // transform property: 'transform'
@@ -74,11 +74,12 @@ Each level of the module can be required as a whole or you can drill down for a 
             timing:    // transition-timing
             delay:     // transition-delay  
             duration:  // transition-duration
-           } 
+           }
         ```
     - events
         + `on(node, eventname, handler, [capture])`:  capture is silently ignored in ie8
         + `off(node, eventname, handler, [capture])`: capture is silently ignored in ie8
+        + `listen(node, eventname, handler, [capture])`: wraps `on` and returns a function that calls `off` for you
         + `filter(selector, fn)`: returns a function handler that only fires when the target matches or is contained in the selector ex: `events.on(list, 'click', events.filter('li > a', handler))`
     - util
         + `requestAnimationFrame(cb)` returns an ID for canceling

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -2,5 +2,6 @@
 var on = require('./on')
   , off = require('./off')
   , filter = require('./filter')
+  , listen = require('./listen')
 
-module.exports = { on, off, filter }
+module.exports = { on, off, filter, listen }

--- a/src/events/listen.js
+++ b/src/events/listen.js
@@ -1,0 +1,16 @@
+var canUseDOM = require('../util/inDOM')
+var on = require('./on')
+var off = require('./off')
+
+var listen = () => {}
+
+if (canUseDOM) {
+  listen = function(node, eventName, handler, capture) {
+    var eventHandler = on(node, eventName, handler, capture);
+    return function() {
+      off(node, eventName, handler, capture);
+    }
+  }
+}
+
+module.exports = listen

--- a/test/events.js
+++ b/test/events.js
@@ -1,6 +1,7 @@
 /*global expect sinon */
 var evt = require('../src/events')
   , simulant = require('simulant')
+  , unlisten
 
 
 describe('Event helpers', () => {
@@ -28,21 +29,36 @@ describe('Event helpers', () => {
     simulant.fire(el, 'click')
   })
 
+  it('should register an event listener with listen', done => {
+    var el = document.getElementById('item-2');
+    evt.listen(el, 'click', () => done());
+    simulant.fire(el, 'click');
+  })
+
+  it('should remove the listener when unlisten() is called', () => {
+    var el = document.getElementById('item-2');
+    unlisten = evt.listen(el, 'click', () => {
+      throw new Error('event fired')
+    });
+    unlisten();
+    simulant.fire(el, 'click');
+  })
+
   it('should filter handlers', () => {
     var span = document.getElementsByTagName('span')[0]
-      , sibling = document.getElementById('item-3') 
+      , sibling = document.getElementById('item-3')
       , parent  = document.getElementById('item-1')
       , filtered = sinon.spy()
       , handler  = sinon.spy();
 
     evt.on(parent, 'click', handler)
     evt.on(parent, 'click', evt.filter('#item-2', filtered))
-    
+
     simulant.fire(span, 'click')
     simulant.fire(sibling, 'click')
 
     expect(filtered.callCount).to.equal(1)
     expect(handler.callCount).to.equal(2)
   })
-  
+
 })


### PR DESCRIPTION
I have something like this in an internal toolset and I've found it helpful with React. It basically just wraps `on` and `off` makes it easy to remove an event listener without having to have a reference to the original `node` or `handler`

```js
// Registers with on and returns a function
var unlisten = listen(window, 'click', () => console.log('on click!'))

// other stuff here

// Calling the function calls off and removes the listener
unlisten()
```

All tests passing locally!