### PR TITLE
util/scrollTo.js: add option to scroll selected item to the top of sc…

### DIFF
--- a/src/util/scrollTo.js
+++ b/src/util/scrollTo.js
@@ -6,7 +6,7 @@ var getOffset = require('../query/offset')
   , raf = require('./requestAnimationFrame')
   , getWindow = require('../query/isWindow')
 
-module.exports = function scrollTo( selected, scrollParent ) {
+module.exports = function scrollTo( selected, scrollParent, scrollToTop = false ) {
   var offset = getOffset(selected)
     , poff   = { top: 0, left: 0 }
     , list, listScrollTop, selectedTop, isWin
@@ -34,7 +34,7 @@ module.exports = function scrollTo( selected, scrollParent ) {
     
     selectedHeight = offset.height
     selectedTop    = offset.top  + (isWin ? 0 : listScrollTop)
-    bottom         = selectedTop + selectedHeight
+    bottom         = scrollToTop ? selectedTop + listHeight : selectedTop + selectedHeight;
 
     listScrollTop = listScrollTop > selectedTop
           ? selectedTop


### PR DESCRIPTION
I added a parameter to the scrollTo function to scroll _selected_ to the top of _scrollParent_, instead to the bottom. Would be great if that could be merged :)