### PR TITLE
Support contains on SVG elements in IE

### DIFF
--- a/src/query/contains.js
+++ b/src/query/contains.js
@@ -1,19 +1,25 @@
 import canUseDOM from '../util/inDOM'
 
 export default (function(){
-  var root = canUseDOM && document.documentElement
-
-  return (root && root.contains)
-    ? function(context, node){ return context.contains(node); }
-    : (root && root.compareDocumentPosition)
-        ? function(context, node){
-            return context === node || !!(context.compareDocumentPosition(node) & 16);
-          }
-        : function(context, node){
-            if (node) do {
-              if (node === context) return true;
-            } while ((node = node.parentNode));
-
-            return false;
-          }
+  // HTML DOM and SVG DOM may have different support levels,
+  // so we need to check on context instead of a document root element.
+  return canUseDOM
+    ? function(context, node){
+        if (context.contains) {
+          return context.contains(node);
+        } else if (context.compareDocumentPosition){
+          return context === node || !!(context.compareDocumentPosition(node) & 16);
+        } else {
+          return fallback(context, node);
+        }
+      }
+    : fallback;
 })()
+
+function fallback(context, node) {
+  if (node) do {
+    if (node === context) return true;
+  } while ((node = node.parentNode));
+
+  return false;
+}


### PR DESCRIPTION
Fixes #11.
Downside is that the polyfill needs to check on every invocation what approach is supported. The only way we could get around that, is to have both an SVG and HTML element in the document when the polyfill is called, test which method is supported for both, and use that. Too involved, in my opinion.