### PR TITLE
fix low IE Events; fix #9

### DIFF
--- a/src/events/on.js
+++ b/src/events/on.js
@@ -10,7 +10,12 @@ if (canUseDOM) {
 
     else if (document.attachEvent)
       return (node, eventName, handler) =>
-          node.attachEvent('on' + eventName, handler);
+          node.attachEvent('on' + eventName, (e) => {
+            e = e || window.event;
+            e.target = e.target || e.srcElement;
+            e.currentTarget = node;
+            handler.call(node, e);
+          });
   })();
 }
 

--- a/src/util/requestAnimationFrame.js
+++ b/src/util/requestAnimationFrame.js
@@ -32,6 +32,7 @@ function fallback(fn) {
 }
 
 compatRaf = cb => raf(cb)
-compatRaf.cancel = id => window[cancel](id)
-
+compatRaf.cancel = id => {
+  window[cancel] && typeof window[cancel] === 'function' && window[cancel](id);
+}
 export default compatRaf


### PR DESCRIPTION
- wrap on() handler so that user don‘t need to care about low IE
- check for cancelRequestAnimationFrame, fix #9