### PR TITLE
Fix null reference on document load

### DIFF
--- a/src/query/matches.js
+++ b/src/query/matches.js
@@ -4,7 +4,7 @@ import qsa from './querySelectorAll'
 
 let matches;
 if (canUseDOM) {
-  let body = document.body
+  let body = document.body || document.head
   let nativeMatch = body.matches
                  || body.matchesSelector
                  || body.webkitMatchesSelector


### PR DESCRIPTION
When the script is included in the `<head>`, it fails attempting to reference `document.body`
which is not yet available at the moment.

Related: https://github.com/intljusticemission/react-big-calendar/issues/283