### PR TITLE
getScrollbarSize does not cached if size of scrollbar is equal to 0

### DIFF
--- a/src/util/scrollbarSize.js
+++ b/src/util/scrollbarSize.js
@@ -3,7 +3,7 @@ import canUseDOM from './inDOM'
 let size;
 
 export default function(recalc) {
-  if (!size || recalc) {
+  if (size !== undefined || recalc) {
     if (canUseDOM) {
       var scrollDiv = document.createElement('div');
 


### PR DESCRIPTION
So every `getScrollbarSize(false)` call causes page reflow on a systems where scollbar size is equal to 0.