### PR TITLE
Fixed null reference on first load

### DIFF
--- a/src/query/matches.js
+++ b/src/query/matches.js
@@ -4,25 +4,37 @@ import qsa from './querySelectorAll'
 
 let matches;
 if (canUseDOM) {
-  let body = document.body
-  let nativeMatch = body.matches
-                 || body.matchesSelector
-                 || body.webkitMatchesSelector
-                 || body.mozMatchesSelector
-                 || body.msMatchesSelector;
+  matches = function () {
+    
+    function ie8MatchesSelector(node, selector) {
+      var matches = qsa(node.document || node.ownerDocument, selector)
+        , i = 0;
 
-  matches = nativeMatch
-    ? (node, selector) => nativeMatch.call(node, selector)
-    : ie8MatchesSelector
+      while (matches[i] && matches[i] !== node) i++;
+
+      return !!matches[i];
+    }
+
+    let fn = null;
+    return function (node, selector) {
+      if (fn === null) {
+        let body = document.body
+
+        if (body) {
+          let nativeMatch = body.matches
+                       || body.matchesSelector
+                       || body.webkitMatchesSelector
+                       || body.mozMatchesSelector
+                       || body.msMatchesSelector;
+
+          fn = nativeMatch
+          ? nativeMatch
+          : ie8MatchesSelector;
+        }
+      }
+      return fn.call(node, selector)
+    }
+  }();
 }
 
 export default matches
-
-function ie8MatchesSelector(node, selector) {
-  var matches = qsa(node.document || node.ownerDocument, selector)
-    , i = 0;
-
-  while (matches[i] && matches[i] !== node) i++;
-
-  return !!matches[i];
-}


### PR DESCRIPTION
Wrapped matches in a factory to ensure we don't try to access the DOM immediately
when this component is loaded. Store matches function to avoid re-caculation.

Fixes #20