### PR TITLE
Support add / remove class in SVG elements (IE11)

### DIFF
--- a/src/class/addClass.js
+++ b/src/class/addClass.js
@@ -4,5 +4,8 @@ export default function addClass(element, className){
   if ( element.classList)
     element.classList.add(className)
   else if ( !hasClass(element, className))
-    element.className = element.className + ' ' + className
+    if (typeof element.className === 'string')
+      element.className = element.className + ' ' + className
+    else
+      element.setAttribute('class', element.className.baseVal + ' ' + className)
 }

--- a/src/class/addClass.js
+++ b/src/class/addClass.js
@@ -7,5 +7,5 @@ export default function addClass(element, className){
     if (typeof element.className === 'string')
       element.className = element.className + ' ' + className
     else
-      element.setAttribute('class', element.className.baseVal + ' ' + className)
+      element.setAttribute('class', (element.className && element.className.baseVal || '') + ' ' + className)
 }

--- a/src/class/hasClass.js
+++ b/src/class/hasClass.js
@@ -3,5 +3,5 @@ export default function hasClass(element, className) {
   if ( element.classList)
     return !!className && element.classList.contains(className)
   else
-    return ` ${element.className} `.indexOf(` ${className} `) !== -1
+    return ` ${element.className.baseVal || element.className} `.indexOf(` ${className} `) !== -1
 }

--- a/src/class/removeClass.js
+++ b/src/class/removeClass.js
@@ -1,11 +1,13 @@
 'use strict';
+function replaceClassName(origClass, classToRemove) {
+  return origClass.replace(new RegExp('(^|\\s)' + classToRemove + '(?:\\s|$)', 'g'), '$1').replace(/\s+/g, ' ').replace(/^\s*|\s*$/g, '');
+}
 
 module.exports = function removeClass(element, className){
   if ( element.classList)
     element.classList.remove(className)
+  else if (typeof element.className === 'string')
+    element.className = replaceClassName(element.className, className)
   else
-    element.className = element.className
-      .replace(new RegExp('(^|\\s)' + className + '(?:\\s|$)', 'g'), '$1')
-      .replace(/\s+/g, ' ')
-      .replace(/^\s*|\s*$/g, '');
+    element.setAttribute('class', replaceClassName(element.className, className))
 }

--- a/src/class/removeClass.js
+++ b/src/class/removeClass.js
@@ -9,5 +9,5 @@ module.exports = function removeClass(element, className){
   else if (typeof element.className === 'string')
     element.className = replaceClassName(element.className, className)
   else
-    element.setAttribute('class', replaceClassName(element.className, className))
+    element.setAttribute('class', replaceClassName(element.className && element.className.baseVal || '', className))
 }


### PR DESCRIPTION
In IE11, SVG elements do not support `classList`, and `className` is not a string; rather, is an object with the properties `baseVal` and `animVal`. This PR checks the type of `className` when it reaches that case and properly manipulates the SVG property when dealing with such an element.