### PR TITLE
Document `scrollbarSize` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,5 @@ Each level of the module can be required as a whole or you can drill down for a 
     - util
         + `requestAnimationFrame(cb)` returns an ID for canceling
             * `requestAnimationFrame.cancel(id)`
+        + `scrollbarSize([recalc])` returns the scrollbar's width size in pixels
         + `scrollTo(element, [scrollParent])`

--- a/src/util/scrollbarSize.js
+++ b/src/util/scrollbarSize.js
@@ -2,7 +2,7 @@ import canUseDOM from './inDOM'
 
 let size;
 
-export default function(recalc) {
+export default function scrollbarSize(recalc) {
   if ((!size && size !== 0) || recalc) {
     if (canUseDOM) {
       var scrollDiv = document.createElement('div');


### PR DESCRIPTION
Closes #39

Perhaps it would be nice to consider documenting the functions using JSDoc in the source files as well, not only to aid developers, but also to enable the use of tools like https://github.com/documentationjs/documentation or similar to automatically generate documentation files