### PR TITLE
Remove spread from default exports

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,11 +1,11 @@
 {
   "dist/dom-helpers.esm.js": {
-    "bundled": 15436,
-    "minified": 8760,
-    "gzipped": 3104,
+    "bundled": 15412,
+    "minified": 8705,
+    "gzipped": 3106,
     "treeshaked": {
-      "rollup": 6895,
-      "webpack": 7461
+      "rollup": 1121,
+      "webpack": 2167
     }
   }
 }

--- a/src/class/hasClass.js
+++ b/src/class/hasClass.js
@@ -1,4 +1,3 @@
-
 export default function hasClass(element, className) {
   if ( element.classList)
     return !!className && element.classList.contains(className)

--- a/src/class/removeClass.js
+++ b/src/class/removeClass.js
@@ -1,9 +1,8 @@
-'use strict';
 function replaceClassName(origClass, classToRemove) {
   return origClass.replace(new RegExp('(^|\\s)' + classToRemove + '(?:\\s|$)', 'g'), '$1').replace(/\s+/g, ' ').replace(/^\s*|\s*$/g, '');
 }
 
-module.exports = function removeClass(element, className){
+export default function removeClass(element, className){
   if ( element.classList)
     element.classList.remove(className)
   else if (typeof element.className === 'string')

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,42 @@
-'use strict';
+import { on, off, filter, listen } from './events'
+import {
+  matches,
+  height,
+  width,
+  offset,
+  offsetParent,
+  position,
+  contains,
+  scrollParent,
+  scrollTop,
+  querySelectorAll,
+  closest
+} from './query'
 import style from './style'
-import events from './events'
-import query from './query'
 import activeElement from './activeElement'
 import ownerDocument from './ownerDocument'
 import ownerWindow from './ownerWindow'
 import requestAnimationFrame from './util/requestAnimationFrame';
 
-export * from './events'
-export * from './query'
 export {
+  // events
+  on,
+  off,
+  filter,
+  listen,
+  // query
+  matches,
+  height,
+  width,
+  offset,
+  offsetParent,
+  position,
+  contains,
+  scrollParent,
+  scrollTop,
+  querySelectorAll,
+  closest,
+  //
   style,
   activeElement,
   ownerDocument,
@@ -18,8 +45,24 @@ export {
 }
 
 export default {
-  ...events,
-  ...query,
+  // events
+  on,
+  off,
+  filter,
+  listen,
+  // query
+  matches,
+  height,
+  width,
+  offset,
+  offsetParent,
+  position,
+  contains,
+  scrollParent,
+  scrollTop,
+  querySelectorAll,
+  closest,
+  //
   style,
   activeElement,
   ownerDocument,

--- a/src/ownerDocument.js
+++ b/src/ownerDocument.js
@@ -1,4 +1,3 @@
-
 export default function ownerDocument(node) {
   return (node && node.ownerDocument) || document;
 }

--- a/src/query/isWindow.js
+++ b/src/query/isWindow.js
@@ -1,4 +1,3 @@
-
 export default function getWindow(node) {
   return node === node.window
     ? node

--- a/src/query/matches.js
+++ b/src/query/matches.js
@@ -1,4 +1,3 @@
-
 import canUseDOM from '../util/inDOM'
 import qsa from './querySelectorAll'
 

--- a/src/style/removeStyle.js
+++ b/src/style/removeStyle.js
@@ -1,4 +1,3 @@
-
 export default function removeStyle(node, key){
   return ('removeProperty' in node.style)
     ? node.style.removeProperty(key)

--- a/src/util/hyphenate.js
+++ b/src/util/hyphenate.js
@@ -1,4 +1,3 @@
-
 let rUpper = /([A-Z])/g;
 
 export default function hyphenate(string) {

--- a/src/util/inDOM.js
+++ b/src/util/inDOM.js
@@ -1,4 +1,3 @@
-
 export default !!(
   typeof window !== 'undefined' &&
   window.document &&


### PR DESCRIPTION
Spread operator is toplevel operation which bundler cannot consider
safe. Passing all imports to object literal explicitly allows bundler to
consider it as pure value.

Also I cleaned up files a bit.

P.S if you will change `merge` button to `squash and merge` you will omit ugly merge commit.