### PR TITLE
Provide treeshakable animation frame api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import query from './query'
 import activeElement from './activeElement'
 import ownerDocument from './ownerDocument'
 import ownerWindow from './ownerWindow'
-import requestAnimationFrame from './util/requestAnimationFrame';
+import { raf, caf } from './util/animationFrame';
 
 export * from './events'
 export * from './query'
@@ -14,7 +14,8 @@ export {
   activeElement,
   ownerDocument,
   ownerWindow,
-  requestAnimationFrame,
+  raf,
+  caf
 }
 
 export default {
@@ -24,5 +25,6 @@ export default {
   activeElement,
   ownerDocument,
   ownerWindow,
-  requestAnimationFrame,
+  raf,
+  caf
 }

--- a/src/util/animationFrame.js
+++ b/src/util/animationFrame.js
@@ -2,7 +2,7 @@ import canUseDOM from './inDOM'
 
 let vendors = ['', 'webkit', 'moz', 'o', 'ms']
 let cancel = 'clearTimeout'
-let raf    = fallback
+let rafImpl    = fallback
 let compatRaf
 
 let getKey = (vendor, k) =>
@@ -14,7 +14,7 @@ if (canUseDOM) {
 
     if (rafKey in window) {
       cancel = getKey(vendor, 'cancel')
-      return raf = cb => window[rafKey](cb)
+      return rafImpl = cb => window[rafKey](cb)
     }
   })
 }
@@ -30,8 +30,7 @@ function fallback(fn) {
   return req;
 }
 
-compatRaf = cb => raf(cb)
-compatRaf.cancel = id => {
+export let raf = cb => rafImpl(cb)
+export let caf = id => {
   window[cancel] && typeof window[cancel] === 'function' && window[cancel](id);
 }
-export default compatRaf

--- a/src/util/scrollTo.js
+++ b/src/util/scrollTo.js
@@ -2,7 +2,7 @@ import getOffset from '../query/offset'
 import height from '../query/height'
 import getScrollParent from '../query/scrollParent'
 import scrollTop from '../query/scrollTop'
-import raf from './requestAnimationFrame'
+import { raf } from './animationFrame'
 import getWindow from '../query/isWindow'
 
 export default function scrollTo(selected, scrollParent) {

--- a/test/util.js
+++ b/test/util.js
@@ -1,4 +1,4 @@
-var raf = require('../src/util/requestAnimationFrame')
+var { raf } = require('../src/util/animationFrame')
 var scrollbarSize = require('../src/util/scrollbarSize')
 
 describe('utils', () => {


### PR DESCRIPTION
In this diff I moved `cancel` from static property to export which will
allow webpack to treeshake it out when it is not unused.

To prevent creating `default` field in cjs I converted api to pair of
named exports (`raf` and `caf`) and renamed module to `animationFrame`.

Here's an output
```
var raf = exports.raf = function raf(cb) {
  return rafImpl(cb);
};
var caf = exports.caf = function caf(id) {
  window[cancel] && typeof window[cancel] === 'function' && window[cancel](id);
};
```

This is a breaking change and I think it should be considered
separately from treeshaking branch.