### PR TITLE
fix: swap scrollTo arguments in scrollAccessor

### DIFF
--- a/src/getScrollAccessor.ts
+++ b/src/getScrollAccessor.ts
@@ -16,7 +16,7 @@ export default function getscrollAccessor(
     }
 
     if (win) {
-      win.scrollTo(val, win[offset])
+      win.scrollTo(win[offset], val)
     } else {
       node[prop] = val
     }


### PR DESCRIPTION
Hey ! 

I was trying to update [scroll-behavior](https://github.com/taion/scroll-behavior) to use dom-helpers v5. 

The migration was straight-forward (thanks for that !) 

But I ran into a problem with the scrollTop function behaving differently than in v3. This PR should fix that. 

