### PR TITLE
Add missing exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,15 @@ require('dom-helpers/css')(node, { width: '40px' })
   - `removeClass(element, className)`
   - `hasClass(element, className)`
   - `toggleClass(element, className)`
-  - `css(element, propName, [value])` or `style(element, objectOfPropValues)`
-  - `removeStyle(element, styleName)`
+  - `style(element, propName)` or `style(element, objectOfPropValues)`
   - `getComputedStyle(element)` -> `getPropertyValue(name)`
   - `animate(node, properties, duration, easing, callback)` programmatically start css transitions
   - `transitionEnd(node, handler, [duration])` listens for transition end, and ensures that the handler if called even if the transition fails to fire its end event. Will attempt to read duration from the element, otherwise one can be provided
   - `addEventListener(node, eventName, handler, [options])`:
   - `removeEventListener(node, eventName, handler, [options])`:
   - `listen(node, eventName, handler, [options])`: wraps `addEventlistener` and returns a function that calls `removeEventListener` for you
-  - `filterEventHandler(selector, fn)`: returns a function handler that only fires when the target matches or is contained in the selector ex: `on(list, 'click', filterEventHandler('li > a', handler))`
-  - `animationFrame.request(cb)` returns an ID for canceling
-  - `animationFrame.cancel(id)`
+  - `filter(selector, fn)`: returns a function handler that only fires when the target matches or is contained in the selector ex: `on(list, 'click', filter('li > a', handler))`
+  - `requestAnimationFrame(cb)` returns an ID for canceling
+  - `cancelAnimationFrame(id)`
   - `scrollbarSize([recalc])` returns the scrollbar's width size in pixels
   - `scrollTo(element, [scrollParent])`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import activeElement from './activeElement'
 import addClass from './addClass'
 import addEventListener from './addEventListener'
+import animate from './animate'
 import {
   cancel as cancelAnimationFrame,
   request as requestAnimationFrame,
@@ -9,6 +10,7 @@ import closest from './closest'
 import contains from './contains'
 import style from './css'
 import filter from './filterEventHandler'
+import getComputedStyle from './getComputedStyle'
 import hasClass from './hasClass'
 import height from './height'
 import listen from './listen'
@@ -21,17 +23,23 @@ import position from './position'
 import querySelectorAll from './querySelectorAll'
 import removeClass from './removeClass'
 import removeEventListener from './removeEventListener'
+import scrollbarSize from './scrollbarSize'
+import scrollLeft from './scrollLeft'
 import scrollParent from './scrollParent'
+import scrollTo from './scrollTo'
 import scrollTop from './scrollTop'
 import toggleClass from './toggleClass'
+import transitionEnd from './transitionEnd'
 import width from './width'
 
 export {
   addEventListener,
   removeEventListener,
+  animate,
   filter,
   listen,
   style,
+  getComputedStyle,
   activeElement,
   ownerDocument,
   ownerWindow,
@@ -44,7 +52,10 @@ export {
   offsetParent,
   position,
   contains,
+  scrollbarSize,
+  scrollLeft,
   scrollParent,
+  scrollTo,
   scrollTop,
   querySelectorAll,
   closest,
@@ -52,14 +63,17 @@ export {
   removeClass,
   hasClass,
   toggleClass,
+  transitionEnd,
 }
 
 export default {
   addEventListener,
   removeEventListener,
+  animate,
   filter,
   listen,
   style,
+  getComputedStyle,
   activeElement,
   ownerDocument,
   ownerWindow,
@@ -72,7 +86,10 @@ export default {
   offsetParent,
   position,
   contains,
+  scrollbarSize,
+  scrollLeft,
   scrollParent,
+  scrollTo,
   scrollTop,
   querySelectorAll,
   closest,
@@ -80,4 +97,5 @@ export default {
   removeClass,
   hasClass,
   toggleClass,
+  transitionEnd,
 }


### PR DESCRIPTION
This re-adds a handful of exported utilities that were dropped from the index file in #55. It looks like that may have been inadvertent due to the translation of `export *` to explicit named exports (example here: https://github.com/react-bootstrap/dom-helpers/pull/55/files#diff-1fdf421c05c1140f6d71444ea2b27638L10).

Also updated the README function documentation to match current export names.

I also noticed #61 while I was poking around. It looks like `css` is the forward-looking name, since it was introduced recently in #55. If that is the desired direction, I can update this PR to add a `css` export and update docs/internal names. We'd still need to export `style` until it can be removed in a major version, but it can be marked as deprecated now using a JSDoc/TSDoc tag.