### PR TITLE
fix: Fix offset calculation

### DIFF
--- a/src/offset.ts
+++ b/src/offset.ts
@@ -16,8 +16,8 @@ export default function offset(node: HTMLElement) {
     box = node.getBoundingClientRect()
 
   box = {
-    top: box.top + scrollTop(node) - (docElem.clientTop || 0),
-    left: box.left + scrollLeft(node) - (docElem.clientLeft || 0),
+    top: box.top + scrollTop(docElem) - (docElem.clientTop || 0),
+    left: box.left + scrollLeft(docElem) - (docElem.clientLeft || 0),
     width: box.width,
     height: box.height,
   }


### PR DESCRIPTION
At least, this is what v3.4.0 was doing: https://github.com/react-bootstrap/dom-helpers/blob/71fd00911d87e27b6b17555cb524bafcf6b9f993/src/query/offset.js#L22-L23