### PR TITLE
Weird error - TypeError: can't access property "baseVal", element.className is undefined

### DIFF
--- a/src/hasClass.ts
+++ b/src/hasClass.ts
@@ -12,7 +12,7 @@ export default function hasClass(
     return !!className && element.classList.contains(className)
 
   return (
-    ` ${element.className.baseVal || element.className} `.indexOf(
+    ` ${element.className || element.className.baseVal} `.indexOf(
       ` ${className} `
     ) !== -1
   )


### PR DESCRIPTION
I've got error "TypeError: can't access property "baseVal", element.className is undefined" from this file with react, after "yarn upgrade". This is the only way to fix it. Take a look.