### PR TITLE
Add side effects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "lib/cjs/index.js",
   "types": "lib/cjs/index.d.ts",
   "module": "lib/esm/index.js",
+  "sideEffects": false,
   "keywords": [
     "dom-helpers",
     "react-component",


### PR DESCRIPTION
Add side effects to package.json, to help bundlers cut unused code more better. Good with named imports.