### PR TITLE
fix: ignore bubbled transitionend when emulating transition end

### DIFF
--- a/src/transitionEnd.ts
+++ b/src/transitionEnd.ts
@@ -18,14 +18,9 @@ function emulateTransitionEnd(element: HTMLElement, duration: number, padding = 
     if (!called) triggerEvent(element, 'transitionend', true);
   }, duration + padding);
 
-  const remove = listen(
-    element,
-    'transitionend',
-    () => {
-      called = true;
-    },
-    { once: true }
-  );
+  const remove = listen(element, 'transitionend', (e) => {
+    if (e.target === element) called = true;
+  });
 
   return () => {
     clearTimeout(handle);

--- a/test/transition.js
+++ b/test/transition.js
@@ -35,4 +35,20 @@ describe('transitionEnd', () => {
     clock.tick(200)
     expect(handler2.callCount).to.equal(1)
   })
+
+  it('should still emulate transitionend when only a child fires the event', () => {
+    const el = document.createElement('div')
+    const child = document.createElement('span')
+    el.appendChild(child)
+    el.style.transitionDuration = '500ms'
+
+    const handler = sinon.spy()
+    transitionEnd(el, handler)
+
+    child.dispatchEvent(new Event('transitionend', { bubbles: true }))
+    clock.tick(600)
+
+    const ownEvents = handler.getCalls().filter((call) => call.args[0].target === el)
+    expect(ownEvents.length).to.equal(1)
+  })
 })


### PR DESCRIPTION
Fixes #184 

A `transitionend` bubbling from a child node sets `called = true`, which cancels the fallback timer. react-bootstrap's `transitionEndListener` ignores events whose target isn't the element, so when the element itself never fires (e.g. Bootstrap's `transition: none` under `prefers-reduced-motion`) the transition never completes and modals get stuck open. See react-bootstrap/react-bootstrap#6153

Only count the event as seen when it was fired on the element itself

Added a test that fires a bubbling `transitionend` from a child and checks the emulated event still arrives. Fails on master, passes with the change